### PR TITLE
chore: 누락된 컴포넌트 10종 공개 export 추가

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -148,3 +148,43 @@ export type { KrdsAccordionItemProps, KrdsAccordionItemEmits } from './KrdsAccor
 // Tts 컴포넌트
 export { default as KrdsTts } from './KrdsTts'
 export type { KrdsTtsProps, KrdsTtsEmits, TtsSize, TtsIcon } from './KrdsTts'
+
+// Table 컴포넌트
+export { default as KrdsTable } from './KrdsTable'
+export type { KrdsTableProps, KrdsTableEmits, TableColumn, TableRow } from './KrdsTable'
+
+// Header 컴포넌트
+export { default as KrdsHeader } from './KrdsHeader'
+export type { KrdsHeaderProps } from './KrdsHeader'
+
+// Footer 컴포넌트
+export { default as KrdsFooter } from './KrdsFooter'
+export type { KrdsFooterProps } from './KrdsFooter'
+
+// Disclosure 컴포넌트
+export { default as KrdsDisclosure } from './KrdsDisclosure'
+export type { KrdsDisclosureProps, KrdsDisclosureEmits } from './KrdsDisclosure'
+
+// Identifier 컴포넌트
+export { default as KrdsIdentifier } from './KrdsIdentifier'
+export type { KrdsIdentifierProps, KrdsIdentifierEmits } from './KrdsIdentifier'
+
+// Layout 컴포넌트
+export { default as KrdsLayout } from './KrdsLayout'
+export type { KrdsLayoutProps, KrdsLayoutEmits, ScrollDetails, LayoutSize } from './KrdsLayout'
+
+// SideNavigation 컴포넌트
+export { default as KrdsSideNavigation } from './KrdsSideNavigation'
+export type { KrdsSideNavigationProps, KrdsSideNavigationEmits, SideNavItem, SideNavSubItem, SideNavPopupItem } from './KrdsSideNavigation'
+
+// StructuredList 컴포넌트
+export { default as KrdsStructuredList } from './KrdsStructuredList'
+export type { KrdsStructuredListProps } from './KrdsStructuredList'
+
+// TextList 컴포넌트
+export { default as KrdsTextList } from './KrdsTextList'
+export type { KrdsTextListProps } from './KrdsTextList'
+
+// CriticalAlerts 컴포넌트
+export { default as KrdsCriticalAlerts } from './KrdsCriticalAlerts'
+export type { KrdsCriticalAlertsProps, KrdsCriticalAlertsEmits, AlertType } from './KrdsCriticalAlerts'


### PR DESCRIPTION
## 개요

구현과 Storybook 테스트는 완료됐으나 `src/components/index.ts` 배럴에서 누락되어 **공개 API로 노출되지 않던 컴포넌트 10종**을 추가합니다.

`/sc:cleanup` 분석 중 발견된 항목으로, 해당 컴포넌트들은 2025년 9월에 추가된 이후 배럴이 여러 차례 수정되는 동안에도 export가 누락된 상태였습니다.

## 추가된 컴포넌트

| 컴포넌트 | 구현 규모 | 비고 |
|------|------|------|
| KrdsSideNavigation | 423줄 | 타입 5종 export |
| KrdsTable | 280줄 | TableColumn, TableRow 포함 |
| KrdsLayout | 199줄 | ScrollDetails, LayoutSize 포함 |
| KrdsHeader | 117줄 | |
| KrdsCriticalAlerts | 97줄 | AlertType 포함 |
| KrdsFooter | 96줄 | |
| KrdsDisclosure | 85줄 | |
| KrdsIdentifier | 67줄 | |
| KrdsStructuredList | 56줄 | |
| KrdsTextList | 36줄 | |

## 검증
- `eslint` ✅ (기존 단일 라인 export 스타일 준수)
- `vue-tsc --noEmit` (type-check) ✅
- `pnpm run build` ✅ — 빌드된 `dist/types/index.d.ts`에 10종 모두 포함 확인
- 기존 Storybook 브라우저 테스트(42 stories)에서 이미 검증되던 컴포넌트들

## 참고
- 타입명 충돌 없음 (TableColumn, AlertType, LayoutSize 등 기존 배럴과 미중복 확인)
- 번들 크기: umd 64.7 → 75.8 kB (10종 추가에 따른 정상 증가, tree-shaking으로 미사용 시 영향 없음)