### PR TITLE
fix(accordion): 펼침 상태 스타일 미적용 수정 및 region 역할 추가

### DIFF
--- a/src/components/KrdsAccordionGroup/KrdsAccordion.stories.ts
+++ b/src/components/KrdsAccordionGroup/KrdsAccordion.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { expect } from 'storybook/test'
 import KrdsAccordionGroup from './KrdsAccordionGroup'
 import { KrdsAccordionItem } from '../KrdsAccordionItem'
 import { ref } from 'vue'
@@ -36,7 +37,27 @@ export const Default: Story = {
         <KrdsAccordionItem id="1" :open-item="openItem" title="title1" content="content1" @toggle="handleToggle" />
         <KrdsAccordionItem id="2" :open-item="openItem" title="title2" content="content2" @toggle="handleToggle" />
       </KrdsAccordionGroup>`
-  })
+  }),
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const button = canvas.getByRole('button', { name: 'title1' })
+    const panel = canvasElement.querySelector(`#${button.getAttribute('aria-controls')}`)
+
+    await expect(panel).toHaveAttribute('role', 'region')
+    await expect(panel).toHaveAttribute('aria-labelledby', button.id)
+
+    await expect(button).toHaveAttribute('aria-expanded', 'false')
+    await expect(button).not.toHaveClass('active')
+
+    // 펼침 상태 스타일(화살표 회전, 열림 배경색)은 .btn-accordion.active 에 걸려 있으므로
+    // 버튼 자체에 active 가 붙어야 한다
+    await userEvent.click(button)
+    await expect(button).toHaveAttribute('aria-expanded', 'true')
+    await expect(button).toHaveClass('active')
+
+    await userEvent.click(button)
+    await expect(button).toHaveAttribute('aria-expanded', 'false')
+    await expect(button).not.toHaveClass('active')
+  }
 }
 
 export const Line: Story = {

--- a/src/components/KrdsAccordionItem/KrdsAccordionItem.vue
+++ b/src/components/KrdsAccordionItem/KrdsAccordionItem.vue
@@ -5,6 +5,7 @@
         :id="`accordion-header-${id}`"
         type="button"
         class="btn-accordion"
+        :class="{ active: isOpen }"
         :aria-expanded="isOpen"
         :aria-controls="`accordion-collapse-${id}`"
         @click="openToggle()"
@@ -12,7 +13,7 @@
         <slot name="title">{{ title }}</slot>
       </button>
     </h5>
-    <div :id="`accordion-collapse-${id}`" class="accordion-collapse collapse" :aria-labelledby="`accordion-header-${id}`">
+    <div :id="`accordion-collapse-${id}`" class="accordion-collapse collapse" role="region" :aria-labelledby="`accordion-header-${id}`">
       <div class="accordion-body">
         <slot name="content">{{ content }}</slot>
       </div>


### PR DESCRIPTION
## 문제

아코디언을 펼쳐도 **화살표가 회전하지 않고, 열림 상태 배경/텍스트 색상이 적용되지 않습니다.**

스타일이 걸려 있는 선택자는 버튼 기준입니다:

```css
/* dist/style.css */
.krds-accordion .accordion-item .btn-accordion.active:after { transform: rotate(180deg) }
.krds-accordion .accordion-item .btn-accordion.active { background-color: …; color: …; border-bottom-*-radius: 0 }
```

그러나 `KrdsAccordionItem` 은 래퍼인 `.accordion-item` 에만 `active` 를 부여하고 `.btn-accordion` 에는 부여하지 않아, 위 규칙이 한 번도 매칭되지 않았습니다. 본문이 펼쳐지는 동작은 `.accordion-item.active .accordion-collapse` 규칙이 별도로 있어 정상 동작했기 때문에 드러나지 않았습니다.

참고로 [공식 KRDS Vue 구현](https://www.krds.go.kr/storybook/vue/?path=/docs/components-accordion--docs)의 `AccordionHeader` 도 동일하게 버튼에 `active` 를 부여합니다.

## 변경 사항

- `btn-accordion` 에 `isOpen` 기준 `active` 클래스 바인딩
- 아코디언 패널에 `role="region"` 추가 — 이미 `aria-labelledby` 로 헤더와 연결돼 있어 WAI-ARIA APG 아코디언 패턴을 충족하게 됩니다
- 기본 스토리에 회귀 방지용 `play` 테스트 추가

## 검증

- `pnpm vitest run`: 97/97 통과 (42 파일)
- 수정을 되돌린 상태에서 신규 테스트가 실패하는 것을 확인해, 회귀를 실제로 잡는지 검증했습니다
- `type-check` / `lint` / `build` 통과

## 범위 밖

다중 열기 지원(`v-model` 배열 + `allowMultiple`)은 breaking change 라 별도 PR로 다룹니다. 현재 API는 `openItem === id` 문자열 비교라 한 번에 하나만 펼칠 수 있습니다.