### PR TITLE
fix(styles): w-hide·m-hide 반응형 표시 유틸리티 추가

### DIFF
--- a/src/styles/common/_utilities.scss
+++ b/src/styles/common/_utilities.scss
@@ -1,0 +1,18 @@
+@use 'include' as *;
+
+/* ** area control ** */
+// 원본 저장소 SCSS에는 없는 krds.go.kr 사이트 전용 유틸리티(resources/css/site/output.css).
+// 원본 예제 HTML(critical_alerts.html, carousel.html 등)과 컴포넌트가 참조하므로 라이브러리에 포함한다.
+// w-hide: 데스크톱 숨김·모바일 표시, m-hide: 모바일 숨김
+.w-hide {
+  display: none !important;
+}
+
+@include size-medium {
+  .w-hide {
+    display: block !important;
+  }
+  .m-hide {
+    display: none !important;
+  }
+}

--- a/src/styles/common/common.scss
+++ b/src/styles/common/common.scss
@@ -11,5 +11,7 @@
 
 @use 'reset';
 
+@use 'utilities';
+
 // FIXME 컴포넌트 상으로는 없음
 @use 'site';


### PR DESCRIPTION
## 요약

전 컴포넌트 감사에서 발견된 스타일 누락 수정입니다. `w-hide`(데스크톱 숨김·모바일 표시)·`m-hide`(모바일 숨김) 유틸리티가 원본 저장소 SCSS에는 없고 krds.go.kr 사이트 전용 CSS(`resources/css/site/output.css`)에만 존재해 라이브러리 번들에서 빠져 있었습니다.

- `KrdsCriticalAlerts`가 링크 텍스트를 `span.m-hide`로 감싸는데 유틸리티가 없어 모바일에서 텍스트가 숨겨지지 않던 문제 수정
- `_carousel.scss`의 `.swiper-indicator.w-hide` 규칙이 기본 `w-hide` 규칙 부재로 동작하지 않던 것 보완
- `src/styles/common/_utilities.scss` 신설 후 `common.scss`에서 로드 (출처 주석 포함)

## 검증

- `pnpm build` 통과, 번들에 기본 규칙과 767px 미디어 쿼리 규칙 반영 확인
- KrdsCriticalAlerts·KrdsCarousel Storybook 테스트 6건 통과
- Playwright로 375px/1400px 뷰포트 스크린샷 확인: 모바일에서 링크 텍스트 숨김(`display: none`), 데스크톱에서 표시(`display: inline`)