### PR TITLE
feat(tabs): KrdsTabs 탭 컴포넌트 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ KRDS Vue는 공공 웹서비스에서 반복되는 폼, 내비게이션, 레이�
 
 - **Vue 3 + TypeScript**: Vue 3.5 이상과 타입 정의를 지원합니다.
 - **ESM-only 배포**: modern bundler 환경에 맞춘 ESM 산출물만 제공합니다.
-- **컴포넌트 40+개**: Button, Form, Navigation, Layout, Feedback, Data Display 계열 컴포넌트를 포함합니다.
+- **KRDS 공식 컴포넌트 대응**: [공식 컴포넌트 55종](https://www.krds.go.kr/html/site/component/component_summary.html) 중 43종을 제공하며, 폼 레이아웃·아이콘 등 부가 컴포넌트를 포함해 총 50개 컴포넌트를 제공합니다.
 - **플러그인/개별 import 지원**: 전체 전역 등록 또는 필요한 컴포넌트만 import할 수 있습니다.
 - **KRDS 스타일/토큰 포함**: 패키지 스타일 엔트리에서 토큰, 폰트, 컴포넌트 CSS를 함께 제공합니다.
 - **접근성 고려**: 키보드 조작, ARIA 속성, 포커스 스타일, 고대비 모드를 고려해 구현합니다.
@@ -74,23 +74,16 @@ app.use(KrdsVue, {
 
 ```vue
 <script setup lang="ts">
-import { ref } from 'vue'
-import { KrdsButton, KrdsInput } from '@krds.ui/vue'
+  import { ref } from 'vue'
+  import { KrdsButton, KrdsInput } from '@krds.ui/vue'
 
-const name = ref('')
+  const name = ref('')
 </script>
 
 <template>
-  <KrdsInput
-    v-model="name"
-    label="이름"
-    placeholder="이름을 입력하세요"
-    required
-  />
+  <KrdsInput v-model="name" label="이름" placeholder="이름을 입력하세요" required />
 
-  <KrdsButton variant="primary" size="medium">
-    확인
-  </KrdsButton>
+  <KrdsButton variant="primary" size="medium">확인</KrdsButton>
 </template>
 ```
 
@@ -140,14 +133,29 @@ document.documentElement.setAttribute('data-krds-mode', 'high-contrast')
 
 ## 컴포넌트 범위
 
-대표 컴포넌트는 다음과 같습니다. 전체 목록과 props/events는 [Storybook 문서](https://krds.initializer.org/)에서 확인하세요.
+[KRDS 공식 컴포넌트 목록](https://www.krds.go.kr/html/site/component/component_summary.html) 55종 기준 대응 현황입니다. 각 컴포넌트의 props/events는 [Storybook 문서](https://krds.initializer.org/)에서 확인하세요.
 
-- **Actions**: `KrdsButton`, `KrdsButtonGroup`, `KrdsLink`, `KrdsTag`, `KrdsBadge`
-- **Forms**: `KrdsInput`, `KrdsTextarea`, `KrdsSelect`, `KrdsDateInput`, `KrdsCheckbox`, `KrdsRadio`, `KrdsToggleSwitch`, `KrdsFileUpload`
-- **Navigation**: `KrdsBreadcrumb`, `KrdsPagination`, `KrdsSideNavigation`, `KrdsInPageNavigation`, `KrdsStepIndicator`
-- **Layout**: `KrdsLayout`, `KrdsHeader`, `KrdsFooter`, `KrdsMasthead`, `KrdsIdentifier`
-- **Feedback/Overlay**: `KrdsModal`, `KrdsTooltip`, `KrdsCoachMark`, `KrdsContextualHelp`, `KrdsCriticalAlerts`, `KrdsSpinner`
-- **Data/Content**: `KrdsTable`, `KrdsStructuredList`, `KrdsTextList`, `KrdsPanel`, `KrdsDisclosure`
+| 분류             | 공식 컴포넌트 → 제공 컴포넌트                                                                                                                                                                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 아이덴티티       | 공식 배너 `KrdsMasthead` · 운영기관 식별자 `KrdsIdentifier` · 헤더 `KrdsHeader` · 푸터 `KrdsFooter`                                                                                                                                                                                            |
+| 탐색             | 건너뛰기 링크 `KrdsSkipLink` · 메인 메뉴 `KrdsMainMenu` · 브레드크럼 `KrdsBreadcrumb` · 사이드 메뉴 `KrdsSideNavigation` · 콘텐츠 내 탐색 `KrdsInPageNavigation` · 페이지네이션 `KrdsPagination`                                                                                               |
+| 레이아웃 및 표현 | 구조화 목록 `KrdsStructuredList` · 긴급 공지 `KrdsCriticalAlerts` · 디스클로저 `KrdsDisclosure` · 모달 `KrdsModal` · 배지 `KrdsBadge` · 아코디언 `KrdsAccordionGroup`/`KrdsAccordionItem` · 캐러셀 `KrdsCarousel` · 탭 `KrdsTabs` · 표 `KrdsTable` · 텍스트 목록 `KrdsTextList` · 달력(`KrdsDateInput`에 내장) |
+| 액션             | 링크 `KrdsLink` · 버튼 `KrdsButton`                                                                                                                                                                                                                                                            |
+| 선택             | 라디오 버튼 `KrdsRadio` · 체크박스 `KrdsCheckbox` · 셀렉트 `KrdsSelect` · 태그 `KrdsTag` · 토글 스위치 `KrdsToggleSwitch`                                                                                                                                                                      |
+| 피드백           | 단계 표시기 `KrdsStepIndicator` · 스피너 `KrdsSpinner`                                                                                                                                                                                                                                         |
+| 도움             | 도움 패널·따라하기 패널 `KrdsPanel` · 맥락적 도움말 `KrdsContextualHelp` · 코치마크 `KrdsCoachMark` · 툴팁 `KrdsTooltip` · 음성지원 `KrdsTts`                                                                                                                                                  |
+| 입력             | 텍스트 입력 필드 `KrdsInput` · 텍스트 영역 `KrdsTextarea` · 날짜 입력 필드 `KrdsDateInput` · 파일 업로드 `KrdsFileUpload`                                                                                                                                                                      |
+| 설정             | 언어 변경 `KrdsLanguageSwitcher` · 화면 크기 조정 `KrdsResize`                                                                                                                                                                                                                                 |
+| 콘텐츠           | 숨긴 콘텐츠 `v-sr-only` 디렉티브                                                                                                                                                                                                                                                               |
+
+공식 목록 외 부가 컴포넌트: `KrdsLayout`, `KrdsIcon`, `KrdsButtonGroup`, `KrdsTagGroup`, `KrdsCheckArea`, `KrdsStep`, `KrdsFormGroup`, `KrdsFormLabel`, `KrdsFormHint`
+
+### 미제공 항목
+
+- **플로팅 버튼(FAB)**: 미구현입니다.
+- **이미지**: Storybook에 안내 문서만 제공합니다.
+- **모바일 계열**(범위슬라이드, 뒤로가기 버튼, 바텀시트, 수량 토글, 토스트, 스낵바): 미구현이며, 탭바·스플래시 스크린은 Storybook에 안내 문서만 제공합니다.
+- **파비콘, 접근 가능한 미디어**: 컴포넌트가 아닌 가이드 항목이라 포팅 대상이 아닙니다.
 
 ### 원본 동기화 기준
 

--- a/src/components/KrdsInPageNavigation/KrdsInPageNavigation.stories.ts
+++ b/src/components/KrdsInPageNavigation/KrdsInPageNavigation.stories.ts
@@ -4,7 +4,7 @@ import KrdsInPageNavigation from './KrdsInPageNavigation'
 import type { NavigationItem } from './KrdsInPageNavigation'
 
 const meta: Meta<typeof KrdsInPageNavigation> = {
-  title: 'Components/Navigation/InPageNavigation',
+  title: 'Components/Navigation/KrdsInPageNavigation',
   component: KrdsInPageNavigation,
   parameters: {
     docs: {

--- a/src/components/KrdsLayout/KrdsLayout.stories.ts
+++ b/src/components/KrdsLayout/KrdsLayout.stories.ts
@@ -11,7 +11,7 @@ import KrdsBreadcrumb from '../KrdsBreadcrumb/KrdsBreadcrumb'
 import { KrdsButton } from '../KrdsButton'
 
 const meta: Meta<typeof KrdsLayout> = {
-  title: 'Components/ETC/KrdsLayout',
+  title: 'Components/Layout/KrdsLayout',
   component: KrdsLayout,
   tags: ['autodocs'],
   argTypes: {

--- a/src/components/KrdsTabs/KrdsTabs.stories.ts
+++ b/src/components/KrdsTabs/KrdsTabs.stories.ts
@@ -1,0 +1,188 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { expect } from 'storybook/test'
+import KrdsTabs from './KrdsTabs'
+import { ref } from 'vue'
+
+const meta: Meta = {
+  title: 'Components/Layout/KrdsTabs',
+  component: KrdsTabs,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '탭은 버튼을 눌러 상호배타적인 여러 개의 콘텐츠 섹션을 전환할 수 있는 컴포넌트이다. 탭 버튼 목록과 콘텐츠 패널이 수직으로 쌓여 있는 형태로 표현되며, 사용자는 탭을 선택하여 해당 콘텐츠 섹션을 표시할 수 있다.'
+      }
+    }
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['line', 'fill']
+    }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const defaultTabs = [
+  { id: 'tab1', label: '타이틀 1' },
+  { id: 'tab2', label: '타이틀 2' },
+  { id: 'tab3', label: '타이틀 3' }
+]
+
+// 1. 기본 (라인형)
+export const Default: Story = {
+  name: '기본',
+  render: () => ({
+    components: { KrdsTabs },
+    setup() {
+      return { tabs: defaultTabs }
+    },
+    template: `
+      <KrdsTabs :tabs="tabs">
+        <template #tab1>탭 1 영역</template>
+        <template #tab2>탭 2 영역</template>
+        <template #tab3>탭 3 영역</template>
+      </KrdsTabs>`
+  }),
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const [firstTab, secondTab] = canvas.getAllByRole('tab')
+    const firstButton = firstTab.querySelector('button')!
+    const secondButton = secondTab.querySelector('button')!
+
+    // 초기 상태: 첫 번째 탭 활성 + ARIA 연결
+    await expect(firstTab).toHaveAttribute('aria-selected', 'true')
+    await expect(firstTab).toHaveClass('active')
+    const firstPanel = canvasElement.querySelector(`#${CSS.escape(firstTab.getAttribute('aria-controls')!)}`)
+    await expect(firstPanel).toHaveAttribute('role', 'tabpanel')
+    await expect(firstPanel).toHaveAttribute('aria-labelledby', firstTab.id)
+    await expect(firstPanel).toHaveClass('active')
+    // 초점이 버튼에 있으므로 aria-selected 대신 sr-only 대체 텍스트 제공 (원본 krds_tab 동작)
+    await expect(firstButton.querySelector('.sr-only')).toHaveTextContent('선택됨')
+
+    // 클릭 시 탭 전환
+    await userEvent.click(secondButton)
+    await expect(secondTab).toHaveAttribute('aria-selected', 'true')
+    await expect(firstTab).toHaveAttribute('aria-selected', 'false')
+    const secondPanel = canvasElement.querySelector(`#${CSS.escape(secondTab.getAttribute('aria-controls')!)}`)
+    await expect(secondPanel).toHaveClass('active')
+    await expect(firstPanel).not.toHaveClass('active')
+    await expect(firstButton.querySelector('.sr-only')).toBeNull()
+
+    // 좌우 방향키로 초점 이동
+    secondButton.focus()
+    await userEvent.keyboard('{ArrowLeft}')
+    await expect(firstButton).toHaveFocus()
+    await userEvent.keyboard('{ArrowRight}')
+    await expect(secondButton).toHaveFocus()
+  }
+}
+
+// 2. 버튼형 (fill)
+export const Fill: Story = {
+  name: '버튼형',
+  render: () => ({
+    components: { KrdsTabs },
+    setup() {
+      return { tabs: defaultTabs }
+    },
+    template: `
+      <KrdsTabs :tabs="tabs" variant="fill">
+        <template #tab1>탭 1 영역</template>
+        <template #tab2>탭 2 영역</template>
+        <template #tab3>탭 3 영역</template>
+      </KrdsTabs>`
+  })
+}
+
+// 3. 풀사이즈
+export const Full: Story = {
+  name: '풀사이즈',
+  render: () => ({
+    components: { KrdsTabs },
+    setup() {
+      const tabs = [
+        { id: 'tab1', label: '타이틀 1' },
+        { id: 'tab2', label: '타이틀 2' }
+      ]
+      return { tabs }
+    },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 4rem;">
+        <KrdsTabs :tabs="tabs" full>
+          <template #tab1>라인형 풀사이즈 탭 1 영역</template>
+          <template #tab2>라인형 풀사이즈 탭 2 영역</template>
+        </KrdsTabs>
+        <KrdsTabs :tabs="tabs" variant="fill" full>
+          <template #tab1>버튼형 풀사이즈 탭 1 영역</template>
+          <template #tab2>버튼형 풀사이즈 탭 2 영역</template>
+        </KrdsTabs>
+      </div>`
+  })
+}
+
+// 4. 비활성화
+export const Disabled: Story = {
+  name: '비활성화',
+  render: () => ({
+    components: { KrdsTabs },
+    setup() {
+      const tabs = [
+        { id: 'tab1', label: '타이틀 1' },
+        { id: 'tab2', label: '타이틀 2', disabled: true },
+        { id: 'tab3', label: '타이틀 3' }
+      ]
+      return { tabs }
+    },
+    template: `
+      <KrdsTabs :tabs="tabs">
+        <template #tab1>탭 1 영역</template>
+        <template #tab2>탭 2 영역</template>
+        <template #tab3>탭 3 영역</template>
+      </KrdsTabs>`
+  }),
+  play: async ({ canvas, userEvent }) => {
+    const [firstTab, secondTab] = canvas.getAllByRole('tab')
+    const secondButton = secondTab.querySelector('button')!
+
+    await expect(secondButton).toBeDisabled()
+
+    // 비활성화된 탭은 클릭해도 전환되지 않는다
+    await userEvent.click(secondButton)
+    await expect(secondTab).toHaveAttribute('aria-selected', 'false')
+    await expect(firstTab).toHaveAttribute('aria-selected', 'true')
+  }
+}
+
+// 5. v-model 제어
+export const Controlled: Story = {
+  name: '외부 제어',
+  render: () => ({
+    components: { KrdsTabs },
+    setup() {
+      const activeTab = ref('tab2')
+      return { tabs: defaultTabs, activeTab }
+    },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 2rem;">
+        <p data-testid="active-tab">현재 탭: {{ activeTab }}</p>
+        <KrdsTabs :tabs="tabs" v-model="activeTab">
+          <template #tab1>탭 1 영역</template>
+          <template #tab2>탭 2 영역</template>
+          <template #tab3>탭 3 영역</template>
+        </KrdsTabs>
+      </div>`
+  }),
+  play: async ({ canvas, userEvent }) => {
+    const [firstTab, secondTab] = canvas.getAllByRole('tab')
+
+    // 초기 modelValue가 반영된다
+    await expect(secondTab).toHaveAttribute('aria-selected', 'true')
+
+    // 탭 전환 시 modelValue가 갱신된다
+    await userEvent.click(firstTab.querySelector('button')!)
+    await expect(firstTab).toHaveAttribute('aria-selected', 'true')
+    await expect(canvas.getByTestId('active-tab')).toHaveTextContent('현재 탭: tab1')
+  }
+}

--- a/src/components/KrdsTabs/KrdsTabs.ts
+++ b/src/components/KrdsTabs/KrdsTabs.ts
@@ -1,0 +1,166 @@
+import { computed, defineComponent, h, ref, useId } from 'vue'
+import type { PropType } from 'vue'
+import type { BaseComponentProps } from '@/types'
+
+/**
+ * KRDS Tabs 탭 아이템
+ */
+export interface KrdsTabItem {
+  /** 탭 고유 식별자 (패널 슬롯 이름으로 사용) */
+  id: string
+  /** 탭 버튼 레이블 */
+  label: string
+  /** 비활성화 여부 */
+  disabled?: boolean
+}
+
+/**
+ * 탭 스타일 변형 (line: 라인형, fill: 버튼형)
+ */
+export type KrdsTabsVariant = 'line' | 'fill'
+
+/**
+ * KRDS Tabs 컴포넌트 속성
+ */
+export interface KrdsTabsProps extends BaseComponentProps {
+  /** 탭 아이템 목록 */
+  tabs: KrdsTabItem[]
+  /** 활성 탭 id (v-model) */
+  modelValue?: string
+  /** 탭 스타일 변형 */
+  variant?: KrdsTabsVariant
+  /** 풀사이즈 레이아웃 여부 */
+  full?: boolean
+  /** 선택된 탭의 스크린 리더 대체 텍스트 */
+  selectedText?: string
+}
+
+/**
+ * KRDS Tabs 컴포넌트 이벤트
+ */
+export interface KrdsTabsEmits {
+  (e: 'update:modelValue', id: string): void
+  (e: 'change', id: string): void
+}
+
+export default defineComponent<KrdsTabsProps>({
+  name: 'KrdsTabs',
+  props: {
+    tabs: {
+      type: Array as PropType<KrdsTabItem[]>,
+      required: true
+    },
+    modelValue: {
+      type: String,
+      default: undefined
+    },
+    variant: {
+      type: String as PropType<KrdsTabsVariant>,
+      default: 'line'
+    },
+    full: {
+      type: Boolean,
+      default: false
+    },
+    selectedText: {
+      type: String,
+      default: '선택됨'
+    },
+    class: {
+      type: String,
+      default: undefined
+    }
+  },
+  emits: ['update:modelValue', 'change'],
+  setup(props, { emit, slots }) {
+    /**
+     * 컴포넌트 고유 ID (탭-패널 ARIA 연결용)
+     */
+    const uid = useId()
+    const tabId = (id: string): string => `tab-${uid}-${id}`
+    const panelId = (id: string): string => `panel-${uid}-${id}`
+
+    /**
+     * 비제어 모드에서 사용하는 내부 활성 탭 상태
+     */
+    const internalActiveId = ref(props.tabs.find(tab => !tab.disabled)?.id)
+
+    /**
+     * 현재 활성 탭 id (modelValue 우선)
+     */
+    const activeId = computed(() => props.modelValue ?? internalActiveId.value)
+
+    const selectTab = (tab: KrdsTabItem): void => {
+      if (tab.disabled || tab.id === activeId.value) return
+      internalActiveId.value = tab.id
+      emit('update:modelValue', tab.id)
+      emit('change', tab.id)
+    }
+
+    /**
+     * 좌우 방향키로 탭 버튼 간 초점 이동 (원본 krds_tab 키보드 동작)
+     */
+    const handleKeydown = (event: KeyboardEvent): void => {
+      if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return
+      event.preventDefault()
+      const currentTab = event.currentTarget as HTMLElement
+      const sibling = event.key === 'ArrowRight' ? currentTab.nextElementSibling : currentTab.previousElementSibling
+      sibling?.querySelector('button')?.focus()
+    }
+
+    return () =>
+      h('div', { class: ['krds-tab-area', 'layer', props.class] }, [
+        // 탭 목록
+        h('div', { class: ['tab', props.variant, { full: props.full }] }, [
+          h(
+            'ul',
+            { role: 'tablist' },
+            props.tabs.map(tab =>
+              h(
+                'li',
+                {
+                  key: tab.id,
+                  id: tabId(tab.id),
+                  role: 'tab',
+                  'aria-selected': tab.id === activeId.value,
+                  'aria-controls': panelId(tab.id),
+                  class: { active: tab.id === activeId.value },
+                  onKeydown: handleKeydown
+                },
+                [
+                  h(
+                    'button',
+                    {
+                      type: 'button',
+                      class: 'btn-tab',
+                      disabled: tab.disabled || undefined,
+                      onClick: () => selectTab(tab)
+                    },
+                    [tab.label, tab.id === activeId.value ? h('i', { class: 'sr-only' }, ` ${props.selectedText}`) : null]
+                  )
+                ]
+              )
+            )
+          )
+        ]),
+        // 탭 콘텐츠
+        h(
+          'div',
+          { class: 'tab-conts-wrap' },
+          props.tabs.map(tab =>
+            h(
+              'section',
+              {
+                key: tab.id,
+                id: panelId(tab.id),
+                role: 'tabpanel',
+                'aria-labelledby': tabId(tab.id),
+                class: ['tab-conts', { active: tab.id === activeId.value }]
+              },
+              slots[tab.id]?.()
+            )
+          )
+        )
+      ])
+  }
+})

--- a/src/components/KrdsTabs/index.ts
+++ b/src/components/KrdsTabs/index.ts
@@ -1,0 +1,10 @@
+/**
+ * KRDS Tabs 컴포넌트
+ */
+
+import KrdsTabs from './KrdsTabs'
+import type { KrdsTabsProps, KrdsTabsEmits, KrdsTabItem, KrdsTabsVariant } from './KrdsTabs'
+
+export { KrdsTabs }
+export type { KrdsTabsProps, KrdsTabsEmits, KrdsTabItem, KrdsTabsVariant }
+export default KrdsTabs

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -206,3 +206,7 @@ export type {
 // Carousel 컴포넌트
 export { default as KrdsCarousel } from './KrdsCarousel'
 export type { KrdsCarouselProps, KrdsCarouselEmits, KrdsCarouselVariant, KrdsCarouselPaginationType } from './KrdsCarousel'
+
+// Tabs 컴포넌트
+export { default as KrdsTabs } from './KrdsTabs'
+export type { KrdsTabsProps, KrdsTabsEmits, KrdsTabItem, KrdsTabsVariant } from './KrdsTabs'


### PR DESCRIPTION
## 개요

KRDS 공식 컴포넌트 중 유일하게 미구현으로 남아 있던 탭(Tab)을 구현합니다. 기존에 `_tab.scss` 스타일만 번들에 포함되어 있었고 Vue 컴포넌트는 없었습니다.

- 공식 가이드: https://www.krds.go.kr/html/site/component/component_04_10.html
- 원본 마크업/동작: `html/code/tab.html`, `ui-script.js`의 `krds_tab`

## 구현 내용

- **KrdsTabs** 데이터 주도 단일 컴포넌트 (`h()` 렌더 함수)
  - `tabs` 배열(`{ id, label, disabled? }`) + 탭 id별 패널 슬롯
  - `v-model`(활성 탭 id) 제어/비제어 모두 지원, `change` 이벤트
  - `variant`: `line`(기본)/`fill`, `full` 레이아웃 옵션
  - 원본 krds_tab 동작 포팅: 좌우 방향키 초점 이동, 활성 탭 버튼에 `sr-only` "선택됨" 텍스트, `li[role=tab]`-`section[role=tabpanel]` ARIA 연결(`useId` 기반)
- Storybook 스토리 5종(기본·버튼형·풀사이즈·비활성화·외부 제어) + play 테스트(전환, ARIA, 키보드, disabled)
- README 컴포넌트 대응 현황 갱신 (공식 43종/총 50개)

## 검증

- `pnpm run type-check` 통과
- `pnpm vitest run` 110개 테스트 통과 (신규 5개 포함)
- `pnpm run build:lib` + `size-limit` 통과 (JS 22.87/25 kB brotli)